### PR TITLE
Use correct package ecosystem for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   # Enable version updates for Docker
-  - package-ecosystem: "yarn"
+  - package-ecosystem: "npm"
     # Look for npm packages in the `root` directory
     directory: "/"
     # Check for updates every weekday


### PR DESCRIPTION
Use correct package ecosystem for Dependabot as [documented](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem)