### PR TITLE
User version of Git Release for NPM package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish Package to npmjs
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-      - run: yarn new:publish
+      - run: yarn install --frozen-lockfile
+      - run: yarn publish --new-version ${{ github.event.release.tag_name }} && clean-package restore
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
User version of Git Release for NPM package.

Also switches to trigger on `published` event instead of `created` to make sure workflow does not get triggered for draft releases and replace `npm` commands with `yarn`.