### PR TITLE
Avoid tagging Git repo in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn install --frozen-lockfile
-      - run: yarn publish --new-version ${{ github.event.release.tag_name }} && clean-package restore
+      - run: yarn version --new-version ${{ github.event.release.tag_name }} --no-git-tag-version
+      - run: yarn publish --non-interactive && clean-package restore
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
`yarn publish` tries to create a Git tag. Since workflow is triggered from a GitHub release, which already takes care of creating the Git tag, this is not required. 