### PR TITLE
Remove support for Node 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
         node-version:
           - 16
           - 14
-          - 12
     name: Node.js ${{ matrix.node-version }} Quick
     steps:
       - name: Checkout the repository

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "repository": "swissgrc/postcss-remove-font-face-format",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "peerDependencies": {
     "postcss": "^8.3.0"


### PR DESCRIPTION
Since Node 12 is end of life we can drop support for it